### PR TITLE
remove set-output and bump gha-workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   update_release_draft:
-    uses: Staffbase/gha-workflows/.github/workflows/template_release_drafter.yml@v1.8.0
+    uses: Staffbase/gha-workflows/.github/workflows/template_release_drafter.yml@v1.12.0

--- a/fetchTags.sh
+++ b/fetchTags.sh
@@ -27,5 +27,5 @@ if [[ "$currentTag" =~ $TAG_MATCHER ]]; then
      paste -sd, -)
 fi
 
-echo "::set-output name=tIDs::$tickets"
-echo "::set-output name=tagName::$currentTag"
+echo "tIDs=$tickets" >> $GITHUB_OUTPUT
+echo "tagName=$currentTag" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

remove set-output and bump gha-workflow see https://staffbasehq.slack.com/archives/C03UKRYDV50/p1675668791381859?thread_ts=1665665216.230309&cid=C03UKRYDV50


TODO @flaxel and @soemo we can bump the version after the merge and use it in https://github.com/Staffbase/gha-workflows/blob/3fcca6a7ce28dc4b4f93fe89d676a65fc517880f/.github/workflows/template_jira_tagging.yml#L35